### PR TITLE
[FIX] add pyyaml as a dependency to use the cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dynamic = ["version"]
-# dependencies = ["pandas"]
+dependencies = [
+    "pyyaml",
+]
 
 
 [project.optional-dependencies]


### PR DESCRIPTION
if a common use case is to read config files, then pyyaml should be a dependency on the package.