### PR TITLE
[FIX] spacy does not support numpy 2.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "numpy<2.0.0",
     "pyyaml",
     "scispacy",
     "spacy>=3.0.0",


### PR DESCRIPTION
change requirements to make sure they are compatible.